### PR TITLE
Ignore dynamically computed dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function getElementValues(nodeArguments) {
 
   return elements.map(function(el) {
     return getEvaluatedValue(el);
-  });
+  }).filter(Boolean);
 }
 
 /**
@@ -123,5 +123,6 @@ function getElementValues(nodeArguments) {
  */
 function getEvaluatedValue(node) {
   if (node.type === 'Literal' || node.type === 'StringLiteral') { return node.value; }
+  if (node.type === 'CallExpression') { return ''; }
   return escodegen.generate(node);
 }

--- a/test/amd/dynamicComputedRequire.js
+++ b/test/amd/dynamicComputedRequire.js
@@ -1,0 +1,10 @@
+define([
+  './a'
+], function(a) {
+  'use strict';
+
+  // Dynamic require with compute code
+  require([a.dependency('inner')], function(b) {
+
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -113,4 +113,10 @@ describe('detective-amd', function() {
     assert(deps[0] === 'a');
     assert(deps[1] === 'b');
   });
+
+  it('skips dynamic computed dependencies', function() {
+    var deps = getDepsOf('./amd/dynamicComputedRequire.js');
+    assert(deps.length === 1);
+    assert(deps[0] === './a');
+  });
 });


### PR DESCRIPTION
I've added a test for a use case that's throwing the following exception otherwise:

```
TypeError: this[type] is not a function
 at CodeGenerator.generateExpression (node-detective-amd/node_modules/escodegen/escodegen.js:2456:28)
 at CodeGenerator.Expression.CallExpression (node-detective-amd/node_modules/escodegen/escodegen.js:1880:34)
 at CodeGenerator.generateExpression (node-detective-amd/node_modules/escodegen/escodegen.js:2456:28)
 at generateInternal (node-detective-amd/node_modules/escodegen/escodegen.js:2494:28)
 at Object.generate (node-detective-amd/node_modules/escodegen/escodegen.js:2558:18)
 at getEvaluatedValue (node-detective-amd/index.js:126:20)
 at node-detective-amd/index.js:116:12

```