### PR TITLE
Support expression-based in define expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,11 +111,16 @@ function getLazyLoadedDeps(node) {
  * @returns {String[]} the literal values from the passed array
  */
 function getElementValues(nodeArguments) {
-  var elements = nodeArguments.elements || [];
-
-  return elements.map(function(el) {
-    return getEvaluatedValue(el);
-  }).filter(Boolean);
+  var dependencies = [];
+  if (nodeArguments.type === 'ArrayExpression') {
+    var elements = nodeArguments.elements || [];
+    dependencies = elements.map(function(el) {
+      return getEvaluatedValue(el);
+    }).filter(Boolean);
+  } else {
+    dependencies.push(getEvaluatedValue(nodeArguments));
+  }
+  return dependencies;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var Walker = require('node-source-walk');
 var types = require('ast-module-types');
 var escodegen = require('escodegen');
 var getModuleType = require('get-amd-module-type');
+var parser = require('esprima-fb');
 
 /**
  * @param  {String} src - the string content or AST of an AMD module
@@ -13,7 +14,7 @@ module.exports = function(src, options) {
   options = options || {};
 
   var dependencies = [];
-  var walker = new Walker();
+  var walker = new Walker({parser: parser});
 
   if (typeof src === 'undefined') { throw new Error('src not given'); }
   if (src === '') { return dependencies; }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ module.exports = function(src, options) {
  */
 function getDependencies(node, type, options) {
   var dependencies;
-
   // Note: No need to handle nodeps since there won't be any dependencies
   switch (type) {
     case 'named':
@@ -119,7 +118,10 @@ function getElementValues(nodeArguments) {
       return getEvaluatedValue(el);
     }).filter(Boolean);
   } else {
-    dependencies.push(getEvaluatedValue(nodeArguments));
+    var dep = getEvaluatedValue(nodeArguments);
+    if (dep) {
+      dependencies.push(getEvaluatedValue(nodeArguments));
+    }
   }
   return dependencies;
 }
@@ -130,6 +132,6 @@ function getElementValues(nodeArguments) {
  */
 function getEvaluatedValue(node) {
   if (node.type === 'Literal' || node.type === 'StringLiteral') { return node.value; }
-  if (node.type === 'CallExpression') { return ''; }
+  if (node.type === 'CallExpression' || node.type === 'FunctionExpression') { return ''; }
   return escodegen.generate(node);
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "jscs index.js test/**/*.js bin/*.js && mocha"
+    "test": "jscs index.js test bin && mocha"
   },
   "bin": {
     "detective-amd": "bin/detective-amd.js"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "ast-module-types": "^2.3.1",
     "escodegen": "^1.8.0",
+    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "get-amd-module-type": "^2.0.4",
     "node-source-walk": "^3.0.0"
   },

--- a/test/amd/expressionDefine.js
+++ b/test/amd/expressionDefine.js
@@ -1,0 +1,6 @@
+var depList = ['bar','baz'];
+define('foo', depList + ['anotherBar'], function(a) {
+  'use strict';
+
+  return a;
+});

--- a/test/amd/namedFactory.js
+++ b/test/amd/namedFactory.js
@@ -1,0 +1,6 @@
+define('myModule', function(require) {
+  var b = require('./b');
+  var c = require('./c');
+
+  console.log(b, c);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
-var detective = require('../'),
-    fs     = require('fs'),
-    assert = require('assert'),
-    path   = require('path');
+var detective = require('../');
+var fs     = require('fs');
+var assert = require('assert');
+var path   = require('path');
 
 describe('detective-amd', function() {
   function getDepsOf(filepath, options) {
@@ -17,8 +17,8 @@ describe('detective-amd', function() {
         expression: {
           type: 'CallExpression',
           callee: {
-              type: 'Identifier',
-              name: 'define'
+            type: 'Identifier',
+            name: 'define'
           },
           arguments: [
             {
@@ -37,7 +37,8 @@ describe('detective-amd', function() {
               rest: null,
               generator: false,
               expression: false
-          }]
+            }
+          ]
         }
       }]
     };
@@ -130,6 +131,12 @@ describe('detective-amd', function() {
     var deps = getDepsOf('./amd/dynamicComputedRequire.js');
     assert(deps.length === 1);
     assert(deps[0] === './a');
+  });
+
+  it('expression-based define expressions', function() {
+    var deps = getDepsOf('./amd/expressionDefine.js');
+    assert(deps.length === 1);
+    assert(deps[0] === 'depList + [\'anotherBar\']');
   });
 
   describe('when given the option to omit lazy loaded requires', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,13 @@ describe('detective-amd', function() {
     assert(deps[0] === 'a');
   });
 
+  it('returns the dependencies of the named factory', function() {
+    var deps = getDepsOf('./amd/namedFactory.js');
+    assert(deps.length === 2);
+    assert(deps[0] === './b');
+    assert(deps[1] === './c');
+  });
+
   it('returns the dependencies of the dependency form', function() {
     var deps = getDepsOf('./amd/dep.js');
     assert(deps.length === 2);


### PR DESCRIPTION
```
var depList = ['bar','baz'];
define('foo', depList + ['anotherBar'], function(a) {
  'use strict';

  return a;
});
```
Expression were not supported in named defined expression
node-detective-amd will return the following output:

depList + ['anotherBar']